### PR TITLE
raise menu persistence

### DIFF
--- a/src/map/ai/states/death_state.h
+++ b/src/map/ai/states/death_state.h
@@ -52,7 +52,7 @@ public:
 private:
     CBattleEntity* const m_PEntity;
     duration             m_deathTime;
-    bool                 m_raiseSent{ false };
+    time_point           m_lastRaiseSent;
     time_point           m_raiseTime;
 };
 


### PR DESCRIPTION
if the 'accept raise' menu disappears due to zoning/position change it will come back

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

if the 'accept raise' menu disappears due to zoning/position change it will come back. Closes #23

## Steps to test these changes

# cloudy orb
!additem 1551 
# scroll of instant reraise
!additem 4182
!send testplayer 146
Trade the orb and then wipe in the battlefield. Wait 3 minutes. 
