### PR TITLE
Correct EXP cap to Era values

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3800,15 +3800,15 @@ namespace charutils
                     // Per monster caps pulled from: https://ffxiclopedia.fandom.com/wiki/Experience_Points
                     if (PMember->GetMLevel() <= 50)
                     {
-                        exp = std::fmin(exp, 400.f);
+                        exp = std::fmin(exp, 200.f);
                     }
                     else if (PMember->GetMLevel() <= 60)
                     {
-                        exp = std::fmin(exp, 500.f);
+                        exp = std::fmin(exp, 250.f);
                     }
                     else
                     {
-                        exp = std::fmin(exp, 600.f);
+                        exp = std::fmin(exp, 300.f);
                     }
 
                     if (mobCheck > EMobDifficulty::DecentChallenge)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

https://ffxiclopedia.fandom.com/wiki/Experience_Points?oldid=1109476#Experience_Cap

This reverts the per mob EXP caps back to 75 Wings Era values. With this change the per mob base EXP cap from level 1-50 will be 200, level 51-60 250, and level 61-75 300 (wings era caps) for a mob kill (based on values in the exp_table sql). Afterwards the 2x EXP modifier from config settings will apply, as well as any other bonuses (Exp rings, chain modifiers, etc.). This should equal out to ~400xp chain 0 IT kills from level 1-50 which would be the wings era values for a 2x exp server. Without this change it'd be possible to get 800xp from IT kills which is not really "2x of wings era exp".

Was not possible to make this into a module by the way 😭 however LSB devs said they would likely be moving these functions to lua eventually, at that point it would be possible.

## Steps to test these changes
Kill mobs, gain exp

<!-- Clear and detailed steps to test your changes here -->
